### PR TITLE
Return Chat GPT usage data

### DIFF
--- a/src/chatgpt-operation/api.js
+++ b/src/chatgpt-operation/api.js
@@ -1,7 +1,8 @@
-import { defineOperationApi } from "@directus/extensions-sdk";
 import { Configuration, OpenAIApi } from "openai";
-import { openAIField } from "../configuration/fields";
+
+import { defineOperationApi } from "@directus/extensions-sdk";
 import { getSetting } from "../lib/util";
+import { openAIField } from "../configuration/fields";
 
 export default defineOperationApi({
 	id: "chatgpt-operation",
@@ -36,6 +37,6 @@ export default defineOperationApi({
 		});
 		const response = completion.data.choices[0].message.content;
 
-		return { response: response };
+		return { response: response, usage: completion.data.usage };
 	},
 });


### PR DESCRIPTION
Suggest returning usage data would be handy for calculating token use etc.