### PR TITLE
Fixed typo in stability.ai override label

### DIFF
--- a/src/stable-diffusion-operation/app.js
+++ b/src/stable-diffusion-operation/app.js
@@ -121,7 +121,7 @@ export default defineOperationApp({
 		},
 		{
 			field: 'api_key',
-			name: 'OpenAI API Key Override',
+			name: 'Stability Ai API Key Override',
 			type: 'string',
 			meta: {
 				width: 'full',

--- a/src/stable-diffusion-operation/app.js
+++ b/src/stable-diffusion-operation/app.js
@@ -121,7 +121,7 @@ export default defineOperationApp({
 		},
 		{
 			field: 'api_key',
-			name: 'Stability Ai API Key Override',
+			name: 'Stability AI API Key Override',
 			type: 'string',
 			meta: {
 				width: 'full',


### PR DESCRIPTION
before:

![image](https://github.com/br41nslug/directus-extension-ai-pack/assets/35926/4ba725c3-d8ee-488b-8535-9991f378f98c)
